### PR TITLE
Fix #43

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 		url "https://raw.githubusercontent.com/Devan-Kerman/Devan-Repo/master/"
 	}
 }
-
+//https://raw.githubusercontent.com/Devan-Kerman/Devan-Repo/master/
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -33,11 +33,11 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modApi("me.shedaniel.cloth:cloth-config-fabric:4.11.19") {
+	modApi("me.shedaniel.cloth:cloth-config-fabric:4.11.26") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 
-	modRuntime("me.shedaniel.cloth:cloth-config-fabric:4.11.19") {
+	modRuntime("me.shedaniel.cloth:cloth-config-fabric:4.11.26") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 
@@ -45,7 +45,7 @@ dependencies {
 		transitive(false)
 	}
 
-	modImplementation "net.devtech:arrp:0.4.2"
+	include (modImplementation("net.devtech:arrp:0.4.2"))
 	modRuntime "me.shedaniel:RoughlyEnoughItems:5.12.235"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.33.0+1.16
+	fabric_version=0.34.6+1.16

--- a/src/main/java/fr/anatom3000/gwwhit/GuessWhatWillHappenInThisMod.java
+++ b/src/main/java/fr/anatom3000/gwwhit/GuessWhatWillHappenInThisMod.java
@@ -1,15 +1,15 @@
 package fr.anatom3000.gwwhit;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import fr.anatom3000.gwwhit.config.ModConfig;
+import fr.anatom3000.gwwhit.config.AnnotationExclusionStrategy;
 import fr.anatom3000.gwwhit.registry.BlockEntityRegistry;
 import fr.anatom3000.gwwhit.registry.BlockRegistry;
 import fr.anatom3000.gwwhit.registry.ItemRegistry;
 import fr.anatom3000.gwwhit.registry.NewMaterials;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
-import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
-import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Jankson;
 
 import net.devtech.arrp.api.RRPCallback;
 import net.devtech.arrp.api.RuntimeResourcePack;
@@ -39,7 +39,8 @@ import java.util.Random;
 
 
 public class GuessWhatWillHappenInThisMod implements ModInitializer {
-	public static final Gson GSON = new Gson();
+	//We use a custom ExclusionStrategy to make sure we don't serialize things that break
+	public static final Gson GSON = new GsonBuilder().setExclusionStrategies(new AnnotationExclusionStrategy()).create();
 
 	public static final String MOD_ID = "gwwhit";
 
@@ -66,8 +67,9 @@ public class GuessWhatWillHappenInThisMod implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		AutoConfig.register(ModConfig.class, GsonConfigSerializer::new);
+		AutoConfig.register(ModConfig.class, (definition, configClass) -> new GsonConfigSerializer<>(definition, configClass, GSON));
 
+		
 		ItemRegistry.register();
 		BlockRegistry.register();
 		BlockEntityRegistry.register();

--- a/src/main/java/fr/anatom3000/gwwhit/config/AnnotationExclusionStrategy.java
+++ b/src/main/java/fr/anatom3000/gwwhit/config/AnnotationExclusionStrategy.java
@@ -11,12 +11,12 @@ import java.lang.annotation.Target;
 public class AnnotationExclusionStrategy implements ExclusionStrategy {
     @Override
     public boolean shouldSkipField(FieldAttributes f) {
-        return f.getAnnotation(Exclude.class) == null;
+        return f.getAnnotation(Exclude.class) != null;
     }
     
     @Override
     public boolean shouldSkipClass(Class<?> c) {
-        return c.getAnnotation(Exclude.class) == null; 
+        return c.getAnnotation(Exclude.class) != null; 
     }
     
     @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/fr/anatom3000/gwwhit/config/AnnotationExclusionStrategy.java
+++ b/src/main/java/fr/anatom3000/gwwhit/config/AnnotationExclusionStrategy.java
@@ -1,0 +1,27 @@
+package fr.anatom3000.gwwhit.config;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class AnnotationExclusionStrategy implements ExclusionStrategy {
+    @Override
+    public boolean shouldSkipField(FieldAttributes f) {
+        return f.getAnnotation(Exclude.class) == null;
+    }
+    
+    @Override
+    public boolean shouldSkipClass(Class<?> c) {
+        return c.isAnnotationPresent(Exclude.class);
+    }
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD})
+    public @interface Exclude {
+    
+    }
+}

--- a/src/main/java/fr/anatom3000/gwwhit/config/ModConfig.java
+++ b/src/main/java/fr/anatom3000/gwwhit/config/ModConfig.java
@@ -23,6 +23,7 @@ public final class ModConfig implements ConfigData {
     private static ModConfig CURRENT_CONFIG = null;
     
     @Gui.Excluded
+    @AnnotationExclusionStrategy.Exclude //We make sure gson doesn't try to serialize this field since it's just a cache
     public ShaderEffect shader = null;
     
     private ModConfig() {}
@@ -37,6 +38,10 @@ public final class ModConfig implements ConfigData {
         if (config == null) config = getHolder().getConfig();
       
         CURRENT_CONFIG = config;
+    }
+    
+    public static void createBackup() {
+        CURRENT_CONFIG = new ModConfig();
     }
     
     public static ConfigHolder<ModConfig> getHolder() {


### PR DESCRIPTION
Gson tried to serialize the field `public ShaderEffect shader` that it shouldn't causing a invalid config file. Then trying to load that caused mc to crash. The fix is to add a `ExclusionStrategy` to the gson that removes the field. It's still unknown why this doesn't happen in the development enviroment. Closes #43 