### PR TITLE
Added random dimension

### DIFF
--- a/src/main/java/fr/anatom3000/gwwhit/GWWHIT.java
+++ b/src/main/java/fr/anatom3000/gwwhit/GWWHIT.java
@@ -3,23 +3,15 @@ package fr.anatom3000.gwwhit;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import fr.anatom3000.gwwhit.config.*;
+import fr.anatom3000.gwwhit.dimension.RandomChunkGenerator;
 import fr.anatom3000.gwwhit.registry.*;
 import fr.anatom3000.gwwhit.util.TableRandomizer;
-import net.devtech.arrp.api.RRPCallback;
 import net.devtech.arrp.api.RuntimeResourcePack;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
-import net.fabricmc.fabric.api.loot.v1.FabricLootPoolBuilder;
-import net.fabricmc.fabric.api.loot.v1.event.LootTableLoadingCallback;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.block.Material;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.mob.SilverfishEntity;
-import net.minecraft.item.Items;
-import net.minecraft.loot.condition.RandomChanceLootCondition;
-import net.minecraft.loot.entry.ItemEntry;
-import net.minecraft.loot.provider.number.UniformLootNumberProvider;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,8 +50,7 @@ public class GWWHIT implements ModInitializer {
 	
 	//Caches
 	public static final Map<String, Map<String, String>> TRANSLATIONS = new HashMap<>();
-	
-	
+
 	public static Identifier getId(String path) {
 		return new Identifier(MOD_ID, path);
 	}
@@ -68,6 +59,7 @@ public class GWWHIT implements ModInitializer {
 	public void onInitialize() {
 		Python.load();
 		cacheTranslations();
+		Registry.register(Registry.CHUNK_GENERATOR, new Identifier("gwwhit", "random"), RandomChunkGenerator.CODEC);
 		ItemRegistry.register();
 		BlockRegistry.register();
 		BlockEntityRegistry.register();

--- a/src/main/java/fr/anatom3000/gwwhit/dimension/RandomChunkGenerator.java
+++ b/src/main/java/fr/anatom3000/gwwhit/dimension/RandomChunkGenerator.java
@@ -28,12 +28,7 @@ public class RandomChunkGenerator extends ChunkGenerator {
 
     private final Random random;
 
-    public static List<Block> whitelistedBlocks = Registry.BLOCK
-        .getIds()
-        .stream()
-        .map(Registry.BLOCK::get)
-        .filter(block -> block.getClass() == Block.class)
-        .collect(Collectors.toList());
+    public final List<Block> whitelistedBlocks;
 
     public static final Codec<RandomChunkGenerator> CODEC = RecordCodecBuilder.create((instance) -> instance
             .group(BiomeSource.CODEC.fieldOf("biome_source").forGetter((generator) -> generator.biomeSource))
@@ -42,11 +37,23 @@ public class RandomChunkGenerator extends ChunkGenerator {
     public RandomChunkGenerator(BiomeSource biomeSource) {
         super(biomeSource, new StructuresConfig(false));
         this.random = new Random();
+        this.whitelistedBlocks = Registry.BLOCK
+            .getIds()
+            .stream()
+            .map(Registry.BLOCK::get)
+            .filter(block -> block.getClass() == Block.class)
+            .collect(Collectors.toList());
     }
 
     public RandomChunkGenerator(BiomeSource biomeSource, long seed) {
         super(biomeSource, new StructuresConfig(false));
         this.random = new Random(seed);
+        this.whitelistedBlocks = Registry.BLOCK
+            .getIds()
+            .stream()
+            .map(Registry.BLOCK::get)
+            .filter(block -> block.getClass() == Block.class)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/fr/anatom3000/gwwhit/dimension/RandomChunkGenerator.java
+++ b/src/main/java/fr/anatom3000/gwwhit/dimension/RandomChunkGenerator.java
@@ -1,0 +1,96 @@
+package fr.anatom3000.gwwhit.dimension;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.ChunkRegion;
+import net.minecraft.world.HeightLimitView;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.StructureAccessor;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.StructuresConfig;
+import net.minecraft.world.gen.chunk.VerticalBlockSample;
+
+public class RandomChunkGenerator extends ChunkGenerator {
+
+    private final Random random;
+
+    public static List<Block> whitelistedBlocks = Registry.BLOCK
+        .getIds()
+        .stream()
+        .map(Registry.BLOCK::get)
+        .filter(block -> block.getClass() == Block.class)
+        .collect(Collectors.toList());
+
+    public static final Codec<RandomChunkGenerator> CODEC = RecordCodecBuilder.create((instance) -> instance
+            .group(BiomeSource.CODEC.fieldOf("biome_source").forGetter((generator) -> generator.biomeSource))
+            .apply(instance, instance.stable(RandomChunkGenerator::new)));
+
+    public RandomChunkGenerator(BiomeSource biomeSource) {
+        super(biomeSource, new StructuresConfig(false));
+        this.random = new Random();
+    }
+
+    public RandomChunkGenerator(BiomeSource biomeSource, long seed) {
+        super(biomeSource, new StructuresConfig(false));
+        this.random = new Random(seed);
+    }
+
+    @Override
+    protected Codec<? extends ChunkGenerator> getCodec() {
+        return CODEC;
+    }
+
+    @Override
+    public ChunkGenerator withSeed(long seed) {
+        return this;
+    }
+
+    @Override
+    public void buildSurface(ChunkRegion region, Chunk chunk) {
+    }
+
+
+    @Override
+    public CompletableFuture<Chunk> populateNoise(Executor executor, StructureAccessor accessor, Chunk chunk) {
+        List<Identifier> ids = Registry.BLOCK.getIds().stream().collect(Collectors.toList());
+        BlockPos.Mutable posMutable = new BlockPos.Mutable();
+        return CompletableFuture.supplyAsync(() -> {
+            for (int x = 0; x < 16; ++x) {
+                posMutable.setX(x);
+                for (int z = 0; z < 16; ++z) {
+                    posMutable.setZ(z);
+                    for (int y = 0; y < 50; ++y) {
+                        posMutable.setY(y);
+                        chunk.setBlockState(posMutable, whitelistedBlocks.get(random.nextInt(whitelistedBlocks.size())).getDefaultState(), false);
+                    }
+                }
+            }
+            return chunk;
+        });
+    }
+
+    @Override
+    public int getHeight(int x, int z, Heightmap.Type heightmapType, HeightLimitView heightLimitView) {
+        return 51;
+    }
+
+    @Override
+    public VerticalBlockSample getColumnSample(int x, int z, HeightLimitView heightLimitView) {
+        return new VerticalBlockSample(0, new BlockState[0]);
+    }
+
+}

--- a/src/main/java/fr/anatom3000/gwwhit/dimension/RandomChunkGenerator.java
+++ b/src/main/java/fr/anatom3000/gwwhit/dimension/RandomChunkGenerator.java
@@ -73,7 +73,6 @@ public class RandomChunkGenerator extends ChunkGenerator {
 
     @Override
     public CompletableFuture<Chunk> populateNoise(Executor executor, StructureAccessor accessor, Chunk chunk) {
-        List<Identifier> ids = Registry.BLOCK.getIds().stream().collect(Collectors.toList());
         BlockPos.Mutable posMutable = new BlockPos.Mutable();
         return CompletableFuture.supplyAsync(() -> {
             for (int x = 0; x < 16; ++x) {

--- a/src/main/java/fr/anatom3000/gwwhit/materials/CustomOre.java
+++ b/src/main/java/fr/anatom3000/gwwhit/materials/CustomOre.java
@@ -21,7 +21,6 @@ import net.devtech.arrp.json.models.JModel;
 import net.devtech.arrp.json.recipe.*;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
-import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
@@ -124,8 +123,6 @@ public class CustomOre {
     }
 
     public void onInitialize(NewMaterials.OreInitParam param) {
-        if (itemGroup == null && ConfigManager.getLoadedConfig().content.moreOres.tab == ModConfig.Content.MoreOres.Tab.SEPARATE) itemGroup = FabricItemGroupBuilder.create(GWWHIT.getId("more_ores")).icon(() -> new ItemStack(block)).build();
-        
         Registry.register(Registry.ITEM, materialId, material);
         if (rnd.nextDouble()<0.3D) FuelRegistry.INSTANCE.add(material, rnd.nextInt(1000));
         createTranslations(type.name(), material.getTranslationKey(), param.lang);

--- a/src/main/resources/data/gwwhit/dimension/random.json
+++ b/src/main/resources/data/gwwhit/dimension/random.json
@@ -1,0 +1,11 @@
+{
+    "generator": {
+      "type": "gwwhit:random",
+      "custom_bool": true,
+      "biome_source": {
+        "type": "minecraft:fixed",
+        "biome": "minecraft:plains"
+      }
+    },
+    "type": "gwwhit:random_type"
+  }

--- a/src/main/resources/data/gwwhit/dimension_type/random_type.json
+++ b/src/main/resources/data/gwwhit/dimension_type/random_type.json
@@ -1,0 +1,16 @@
+{
+    "ultrawarm": false,
+    "natural": false,
+    "coordinate_scale": 1,
+    "ambient_light": 0.1,
+    "has_skylight": true,
+    "has_ceiling": false,
+    "infiniburn": "minecraft:infiniburn_overworld",
+    "logical_height" : 256,
+    "has_raids" : false,
+    "respawn_anchor_works": false,
+    "bed_works" : false,
+    "piglin_safe" : false,
+    "height": 256,
+    "min_y": 0
+  }


### PR DESCRIPTION
![2021-06-14_20 47 36](https://user-images.githubusercontent.com/18114966/121943526-f74d1080-cd51-11eb-9d4d-2f140090f3ef.png)

Basically works like the RandomisingBlock, but as a whole dimension

For now there is no way to access this dimension in survival as [customportalapi](https://github.com/kyrptonaught/customportalapi) seems to be broken (i cant download the lib)

So to teleport there you need to run `/execute in gwwhit:random run tp 0 100 0`

also fixed a bug where 2 ore tabs would display